### PR TITLE
feat: implement pagination for journal entries in API routes

### DIFF
--- a/src/app/api/journal/entries/route.ts
+++ b/src/app/api/journal/entries/route.ts
@@ -2,6 +2,21 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
 import { validateCompanyContext } from '@/lib/auth-utils'
 
+interface JournalEntry {
+  id: string;
+  transaction_id: string;
+  date: string;
+  description: string;
+  debit: number;
+  credit: number;
+  chart_account_id: string;
+  company_id: string;
+  transactions: {
+    payee_id?: string;
+    corresponding_category_id?: string;
+  };
+}
+
 export async function GET(request: NextRequest) {
   try {
     // Validate company context
@@ -14,32 +29,55 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const transactionId = searchParams.get('transaction_id');
 
-    let query = supabase
-      .from('journal')
-      .select(`
-        *,
-        transactions!inner(payee_id, corresponding_category_id)
-      `)
-      .eq('company_id', companyId);
+    // Fetch ALL journal entries with pagination
+    let allEntries: JournalEntry[] = [];
+    let page = 0;
+    const pageSize = 1000;
+    let hasMore = true;
 
-    // If transaction_id is provided, filter by it
-    if (transactionId) {
-      query = query.eq('transaction_id', transactionId);
-    }
+    // Fetch all pages of data
+    while (hasMore) {
+      let query = supabase
+        .from('journal')
+        .select(`
+          *,
+          transactions!inner(payee_id, corresponding_category_id)
+        `)
+        .eq('company_id', companyId)
+        .range(page * pageSize, (page + 1) * pageSize - 1)
+        .order('date', { ascending: false });
 
-    const { data: journalEntries, error } = await query
-      .order('date', { ascending: false });
+      // If transaction_id is provided, filter by it
+      if (transactionId) {
+        query = query.eq('transaction_id', transactionId);
+      }
+
+      const { data, error } = await query;
         
-    if (error) {
-      console.error('Error fetching journal entries:', error);
-      return NextResponse.json(
-        { error: 'Failed to fetch journal entries: ' + error.message },
-        { status: 500 }
-      );
+      if (error) {
+        console.error('Error fetching journal entries page:', error);
+        return NextResponse.json(
+          { error: 'Failed to fetch journal entries: ' + error.message },
+          { status: 500 }
+        );
+      }
+
+      if (data && data.length > 0) {
+        allEntries = allEntries.concat(data as JournalEntry[]);
+        
+        // If we got less than pageSize, we've reached the end
+        if (data.length < pageSize) {
+          hasMore = false;
+        } else {
+          page++;
+        }
+      } else {
+        hasMore = false;
+      }
     }
 
     return NextResponse.json(
-      { entries: journalEntries || [] },
+      { entries: allEntries },
       { status: 200 }
     )
 

--- a/src/app/table/page.tsx
+++ b/src/app/table/page.tsx
@@ -1199,7 +1199,7 @@ export default function JournalTablePage() {
             {/* Pagination for Journal table */}
             <div className="mt-2 flex items-center justify-start gap-3">
               <span className="text-xs text-gray-600 whitespace-nowrap">
-                {`${paginationData.endIndex} of ${totalItems}`}
+                {`${paginationData.endIndex?.toLocaleString()} of ${totalItems?.toLocaleString()}`}
               </span>
               <CustomPagination 
                 currentPage={currentPage}


### PR DESCRIPTION
- Enhanced the GET methods in both journal and manual journal API routes to support pagination, allowing retrieval of more than 1000 journal entries.
- Introduced interfaces for JournalEntry and ManualJournalEntry to improve type safety and clarity.
- Updated the response structure to return all fetched entries in a single response.